### PR TITLE
Add scripts from 2017 re:Invent session

### DIFF
--- a/2017/README.md
+++ b/2017/README.md
@@ -1,0 +1,7 @@
+# AWS CLI code samples from re:Invent 2017
+
+This directory contains the AWS CLI code samples presented from the
+"AWS CLI: 2017 and Beyond" session at re:Invent 2017.
+
+The video for this talk is available on youtube:
+https://www.youtube.com/watch?v=W8IyScUGuGI

--- a/2017/alias
+++ b/2017/alias
@@ -1,0 +1,8 @@
+[toplevel]
+
+keychain = 
+  !f() {
+     ACCESS_KEY=$(security find-generic-password -s "aws demo access" -w reinvent)
+     SECRET_KEY=$(security find-generic-password -s "aws demo secret" -w reinvent)
+     echo \{\"AccessKeyId\":\""$ACCESS_KEY"\",\"SecretAccessKey\":\""$SECRET_KEY"\",\"Version\":1\}
+  }; f

--- a/2017/clone
+++ b/2017/clone
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script will list all of your AWS CodeCommit repositories and clone
+# each one into your current working directory.
+#
+# If you provide a "-r | --repository-name" option, it will only clone the
+# repository matching the provided name in your current working directory.
+
+clone() {
+  local repo_name="$1"
+  ssh_url=$(aws codecommit get-repository --repository-name "$repo_name" \
+            --query repositoryMetadata.cloneUrlSsh --output text)
+  git clone "$ssh_url"
+}
+
+
+if [ -z "$1" ]; then
+  for repo_name in $(aws codecommit list-repositories --query "repositories[].repositoryName" --output text); do
+    clone "$repo_name"
+  done
+else
+  case "$1" in
+    -r|--repository-name)
+      shift
+      repo_name="$1"
+      ;;
+    *)
+      echo "usage: clone [-r | --repository-name]" 1>&2
+      exit 1
+  esac
+  clone "$repo_name"
+fi


### PR DESCRIPTION
Content consists of:

* keychain alias used as a credential process provider
* clone script used to clone all AWS CodeCommit repositories

cc @jamesls @JordonPhillips @dstufft @stealthycoin @joguSD 